### PR TITLE
remove window.parent check from contentscript

The manifest 'all_frames' property defaults to false, so the contentscript should not need to perform the window.parent check.

### DIFF
--- a/inpage-toolbar-ui/contentscript.js
+++ b/inpage-toolbar-ui/contentscript.js
@@ -22,15 +22,13 @@ function toggleToolbar(toolbarUI) {
   }
 }
 
-// Handle messages from the add-on background page (only in top level iframes)
-if (window.parent == window) {
-  chrome.runtime.onMessage.addListener(function(msg) {
-    if (msg == "toggle-in-page-toolbar") {
-      if (toolbarUI) {
-        toggleToolbar(toolbarUI);
-      } else {
-        toolbarUI = initToolbar();
-      }
+// Handle messages from the add-on background page
+chrome.runtime.onMessage.addListener(function(msg) {
+  if (msg == "toggle-in-page-toolbar") {
+    if (toolbarUI) {
+      toggleToolbar(toolbarUI);
+    } else {
+      toolbarUI = initToolbar();
     }
-  });
-}
+  }
+});


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
